### PR TITLE
include winsock2.h on windows

### DIFF
--- a/src/rr.h
+++ b/src/rr.h
@@ -39,7 +39,11 @@
 
 #include <string>
 #include <vector>
+#ifdef _WIN32
+#include <winsock2.h>
+#else
 #include <arpa/inet.h>
+#endif
 
 #include "dns.h"
 #include "buffer.h"


### PR DESCRIPTION
include <winsock2.h> instead of <arpa/inet.h> on windows